### PR TITLE
Split large models and save to multiple tiny particles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
+core/__pycache__/
 core/pydb/__pycache__/
 core/pypantip/__pycache__/
 core/pypipe/__pycache__/
 core/pypipe/operations/__pycache__/
+data/cluster/
+data/hasher/
+data/models/
 data/report.csv
 data/report_copy.csv
 derby.log

--- a/core/pypipe/operations/cluster.py
+++ b/core/pypipe/operations/cluster.py
@@ -16,7 +16,6 @@ from sklearn.qda import QDA
 from sklearn.linear_model import SGDClassifier
 
 METHODS = {
-	# TAOTODO: Try other clustering methods
 	'centroid': NearestCentroid(
 		metric='euclidean',#TAOTOREVIEW: Any better metric?
 		shrink_threshold=None

--- a/core/pypipe/operations/mongo.py
+++ b/core/pypipe/operations/mongo.py
@@ -7,7 +7,7 @@ import pymongo
 from pymongo import MongoClient
 from pymongo import InsertOne
 
-def new(host,addr,db,coll):
+def new(host,db,coll):
   conn = {}
   conn['addr']  = "mongodb://{0}:27017/".format(host)
   conn['mongo'] = MongoClient(addr)

--- a/core/pypipe/operations/mongo.py
+++ b/core/pypipe/operations/mongo.py
@@ -1,0 +1,25 @@
+"""
+Model serialiser with MongoDB
+@starcolon projects
+"""
+
+import pymongo
+from pymongo import MongoClient
+from pymongo import InsertOne
+
+def new(host,addr,db,coll):
+  conn = {}
+  conn['addr']  = "mongodb://{0}:27017/".format(host)
+  conn['mongo'] = MongoClient(addr)
+  conn['db']    = self.mongo[db]
+  conn['src']   = self.db[coll]
+  return conn
+
+def save(conn,data):
+  conn['src'].insert_one(data)
+
+def clear(conn):
+  conn['src'].find_one_and_delete({})
+
+def load(conn):
+  return conn['src'].find_one(sort=[('_id', pymongo.DESCENDING)])

--- a/core/pypipe/operations/mongo.py
+++ b/core/pypipe/operations/mongo.py
@@ -9,10 +9,9 @@ from pymongo import InsertOne
 
 def new(host,db,coll):
   conn = {}
-  conn['addr']  = "mongodb://{0}:27017/".format(host)
-  conn['mongo'] = MongoClient(addr)
-  conn['db']    = self.mongo[db]
-  conn['src']   = self.db[coll]
+  conn['mongo'] = MongoClient("mongodb://{0}:27017/".format(host))
+  conn['db']    = conn['mongo'][db]
+  conn['src']   = conn['db'][coll]
   return conn
 
 def save(conn,data):

--- a/core/pypipe/operations/texthasher.py
+++ b/core/pypipe/operations/texthasher.py
@@ -8,7 +8,7 @@ import os.path
 import pickle
 import json
 from .sparsetodense import SparseToDense
-from mongo
+from . import mongo
 from termcolor import colored
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.feature_selection import SelectKBest, chi2

--- a/core/pypipe/operations/texthasher.py
+++ b/core/pypipe/operations/texthasher.py
@@ -74,8 +74,8 @@ def save(operations,path):
 	print('Saving texthasher model...')
 
 	db = mongo.new('localhost',MONGO_DB,MONGO_COLLECTION)
-	db.clear()
-	db.save(operations)
+	mongo.clear(db)
+	mongo.save(db,operations)
 	
 	# for i in range(len(operations)):
 	# 	print('...Saving opr #{0}'.format(i), operations[i])

--- a/core/pypipe/operations/texthasher.py
+++ b/core/pypipe/operations/texthasher.py
@@ -8,6 +8,7 @@ import os.path
 import pickle
 import json
 from .sparsetodense import SparseToDense
+from mongo
 from termcolor import colored
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.feature_selection import SelectKBest, chi2
@@ -17,6 +18,9 @@ from sklearn.decomposition import TruncatedSVD
 from sklearn.decomposition import LatentDirichletAllocation
 from sklearn.decomposition import IncrementalPCA
 from sklearn.decomposition import SparsePCA
+
+MONGO_DB         = 'pantip-model'
+MONGO_COLLECTION = 'hasher'
 
 # Create a text process pipeline (vectorizer)
 def new(stop_words=[],decomposition='SVD',n_components=5):
@@ -68,13 +72,15 @@ def new(stop_words=[],decomposition='SVD',n_components=5):
 
 def save(operations,path):
 	print('Saving texthasher model...')
-	# TAOTODO: Try saving each element on separate file
-	for i in range(len(operations)):
-		print('...Saving opr #{0}'.format(i), operations[i])
-		with open(path + '.' + str(i),'wb+') as f:
-			pickle.dump(operations[i],f,pickle.HIGHEST_PROTOCOL)
-	# with open(path,'wb+') as f:
-	# 	pickle.dump(operations,f,protocal=4)
+
+	db = mongo.new('localhost',MONGO_DB,MONGO_COLLECTION)
+	db.clear()
+	db.save(operations)
+	
+	# for i in range(len(operations)):
+	# 	print('...Saving opr #{0}'.format(i), operations[i])
+	# 	with open(path + '.' + str(i),'wb+') as f:
+	# 		pickle.dump(operations[i],f,pickle.HIGHEST_PROTOCOL)
 
 def load(path):
 	operations = []
@@ -84,8 +90,6 @@ def load(path):
 			operations.append(pickle.load(f))
 	return operations
 
-	# with open(path,'rb') as f:
-	# 	return pickle.load(f,protocal=4)
 
 # Load the transformer pipeline object
 # from the physical file,

--- a/core/pypipe/operations/texthasher.py
+++ b/core/pypipe/operations/texthasher.py
@@ -9,15 +9,10 @@ import pickle
 import json
 from .sparsetodense import SparseToDense
 from termcolor import colored
-from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.feature_selection import SelectKBest, chi2
-from sklearn.linear_model import RidgeClassifier
 from sklearn.neighbors import NearestCentroid
 from sklearn.preprocessing import Normalizer
-from sklearn.decomposition import NMF
-from sklearn.pipeline import make_pipeline
 from sklearn.decomposition import TruncatedSVD
 from sklearn.decomposition import LatentDirichletAllocation
 from sklearn.decomposition import IncrementalPCA
@@ -73,12 +68,24 @@ def new(stop_words=[],decomposition='SVD',n_components=5):
 
 def save(operations,path):
 	print('Saving texthasher model...')
-	with open(path,'wb+') as f:
-		pickle.dump(operations,f,protocal=4)
+	# TAOTODO: Try saving each element on separate file
+	for i in range(len(operations)):
+		print('...Saving opr #{0}'.format(i), operations[i])
+		with open(path + '.' + str(i),'wb+') as f:
+			pickle.dump(operations[i],f,pickle.HIGHEST_PROTOCOL)
+	# with open(path,'wb+') as f:
+	# 	pickle.dump(operations,f,protocal=4)
 
 def load(path):
-	with open(path,'rb') as f:
-		return pickle.load(f,protocal=4)
+	operations = []
+	i = 0
+	while os.path.isfile(path + '.' + str(i)):
+		with open(path + '.' + str(i),'rb') as f:
+			operations.append(pickle.load(f))
+	return operations
+
+	# with open(path,'rb') as f:
+	# 	return pickle.load(f,protocal=4)
 
 # Load the transformer pipeline object
 # from the physical file,

--- a/core/pypipe/operations/texthasher.py
+++ b/core/pypipe/operations/texthasher.py
@@ -87,7 +87,7 @@ def save(operations,path):
 			save_chunk(path, i, c)
 	else:
 		# Small model, just save it with typical method
-		with open(path, 'wb+') as f:
+		with open(path + '.0', 'wb+') as f:
 			pickle.dump(operations, f)
 
 def save_chunk(path,i,chunk):
@@ -111,14 +111,16 @@ def split_to_chunks(bulky_str,chunk_size):
 		pos += chunk_size
 
 
-
 def load(path):
-	operations = []
 	i = 0
+	s = ''
+	# Load all chunks, assembly them into one single object
 	while os.path.isfile(path + '.' + str(i)):
+		print(colored('Loading chunk #{0}'.format(i), 'yellow'))
 		with open(path + '.' + str(i),'rb') as f:
-			operations.append(pickle.load(f))
-	return operations
+			s += pickle.load(f)
+	
+	return pickle.loads(s)
 
 
 # Load the transformer pipeline object

--- a/core/textprocess.py
+++ b/core/textprocess.py
@@ -20,11 +20,9 @@ from pypipe.operations import textcluster
 
 
 REPO_DIR = os.getenv('PANTIPLIBR','../..')
-TEXT_VECTORIZER_PATH	= '{0}/data/hasher/00'.format(REPO_DIR)
-TAG_HASHER_PATH       = '{0}/data/hasher/33'.format(REPO_DIR)
-TEXT_CLUSTER_PATH     = '{0}/data/cluster/00'.format(REPO_DIR)
-CONTENT_CLUSTER_PATH  = '{0}/data/cluster/22'.format(REPO_DIR)
-CLF_PATH              = '{0}/data/cluster/ff'.format(REPO_DIR)
+TEXT_VECTORIZER_PATH  = '{0}/data/models/vectoriser'.format(REPO_DIR)
+TAG_HASHER_PATH       = '{0}/data/models/taghash'.format(REPO_DIR)
+CLF_PATH              = '{0}/data/models/clf'.format(REPO_DIR)
 STOPWORDS_PATH        = '{0}/data/words/stopwords.txt'.format(REPO_DIR)
 CSV_REPORT_PATH       = '{0}/data/report.csv'.format(REPO_DIR)
 
@@ -181,10 +179,6 @@ def train_sentiment_capture(stopwords,save=False):
 	# Self-validation
 	num_correct  = len([1 for y,y0 in zip(Y_,Y) if y==y0])
 	predict_rate = 100*float(num_correct)/float(len(Y))
-	# print(colored('====== TRAINING LABELS =====','magenta'))
-	# print(Y)
-	# print(colored('========= PREDICTED ========','magenta'))
-	# print(list(Y_))
 	print(colored('=========== RESULTS ========','magenta'))
 	print('    overall accuracy:   {0:.2f} %'.format(predict_rate))
 
@@ -216,9 +210,9 @@ def train_sentiment_capture(stopwords,save=False):
 	#Save the trained models
 	if save:
 		print(colored('Saving models...','cyan'))
-		texthasher.save(topicHasher,TEXT_VECTORIZER_PATH)
 		taghasher.save(tagHasher,TAG_HASHER_PATH)
 		cluster.save(clf,CLF_PATH)
+		texthasher.save(topicHasher,TEXT_VECTORIZER_PATH)
 		print(colored('[DONE]','green'))
 
 

--- a/process
+++ b/process
@@ -40,25 +40,25 @@ rm data/hasher/*
 
 # [SGD] tends to stress CPU most especially on larger dataset.
 
-CLUSTER="sgd"
+CLUSTER="centroid --save"
 
 # Batch trainings
 python3 core/textprocess.py --decom SVD --n 400 --tagdim 16 --cluster $CLUSTER
-python3 core/requeue.py
-python3 core/textprocess.py --decom SVD --n 200 --tagdim 16 --cluster $CLUSTER
-python3 core/requeue.py
-python3 core/textprocess.py --decom SVD --n 100 --tagdim 16 --cluster $CLUSTER
-python3 core/requeue.py
-python3 core/textprocess.py --decom SVD --n 50 --tagdim 16 --cluster $CLUSTER
-python3 core/requeue.py
+# python3 core/requeue.py
+# python3 core/textprocess.py --decom SVD --n 200 --tagdim 16 --cluster $CLUSTER
+# python3 core/requeue.py
+# python3 core/textprocess.py --decom SVD --n 100 --tagdim 16 --cluster $CLUSTER
+# python3 core/requeue.py
+# python3 core/textprocess.py --decom SVD --n 50 --tagdim 16 --cluster $CLUSTER
+# python3 core/requeue.py
 
-python3 core/textprocess.py --decom LDA --n 50 --tagdim 16 --cluster $CLUSTER
-python3 core/requeue.py
-python3 core/textprocess.py --decom LDA --n 25 --tagdim 16 --cluster $CLUSTER
-python3 core/requeue.py
-python3 core/textprocess.py --decom LDA --n 10 --tagdim 16 --cluster $CLUSTER
-python3 core/requeue.py
-python3 core/textprocess.py --decom LDA --n 5 --tagdim 16 --cluster $CLUSTER
+# python3 core/textprocess.py --decom LDA --n 50 --tagdim 16 --cluster $CLUSTER
+# python3 core/requeue.py
+# python3 core/textprocess.py --decom LDA --n 25 --tagdim 16 --cluster $CLUSTER
+# python3 core/requeue.py
+# python3 core/textprocess.py --decom LDA --n 10 --tagdim 16 --cluster $CLUSTER
+# python3 core/requeue.py
+# python3 core/textprocess.py --decom LDA --n 5 --tagdim 16 --cluster $CLUSTER
 # python3 core/requeue.py
 
 # python3 core/textprocess.py --decom PCA --n 400 --tagdim 16 --cluster $CLUSTER


### PR DESCRIPTION
Truncated SVD (LSA) model usually takes up to a few gigabytes of space after training on thousands of samples. This may not be possible of OSX developers to save their own model as a single part.
